### PR TITLE
Proper create_makefile

### DIFF
--- a/ext/c/extconf.rb
+++ b/ext/c/extconf.rb
@@ -10,4 +10,4 @@ else
   $CFLAGS << ' -O3'
 end
 
-create_makefile('liboga/liboga')
+create_makefile('liboga')


### PR DESCRIPTION
If using `create_makefile('liboga/liboga')` gem install oga will compile liboga.so into path-to-oga-gem/lib/liboga/liboga.so
In oga.rb you are using `require_relative 'liboga'` so this will result in a failing require.

Cheers benny
