### PR TITLE
Alias to_xml methods as to_html

### DIFF
--- a/lib/oga/xml/attribute.rb
+++ b/lib/oga/xml/attribute.rb
@@ -89,6 +89,7 @@ module Oga
 
         return %Q(#{full_name}="#{value}")
       end
+      alias_method :to_html, :to_xml
 
       ##
       # @return [String]

--- a/lib/oga/xml/cdata.rb
+++ b/lib/oga/xml/cdata.rb
@@ -12,6 +12,7 @@ module Oga
       def to_xml
         return "<![CDATA[#{text}]]>"
       end
+      alias_method :to_html, :to_xml
     end # Cdata
   end # XML
 end # Oga

--- a/lib/oga/xml/character_node.rb
+++ b/lib/oga/xml/character_node.rb
@@ -27,6 +27,7 @@ module Oga
       def to_xml
         return text.to_s
       end
+      alias_method :to_html, :to_xml
 
       ##
       # @return [String]

--- a/lib/oga/xml/comment.rb
+++ b/lib/oga/xml/comment.rb
@@ -12,6 +12,7 @@ module Oga
       def to_xml
         return "<!--#{text}-->"
       end
+      alias_method :to_html, :to_xml
     end # Comment
   end # XML
 end # Oga

--- a/lib/oga/xml/doctype.rb
+++ b/lib/oga/xml/doctype.rb
@@ -60,6 +60,7 @@ module Oga
 
         return segments + '>'
       end
+      alias_method :to_html, :to_xml
 
       ##
       # Inspects the doctype.

--- a/lib/oga/xml/document.rb
+++ b/lib/oga/xml/document.rb
@@ -70,6 +70,7 @@ module Oga
 
         return xml
       end
+      alias_method :to_html, :to_xml
 
       ##
       # Inspects the document and its child nodes. Child nodes are indented for

--- a/lib/oga/xml/element.rb
+++ b/lib/oga/xml/element.rb
@@ -216,6 +216,7 @@ module Oga
 
         return "<#{ns}#{name}#{attrs}>#{body}</#{ns}#{name}>"
       end
+      alias_method :to_html, :to_xml
 
       ##
       # @return [String]

--- a/lib/oga/xml/processing_instruction.rb
+++ b/lib/oga/xml/processing_instruction.rb
@@ -27,6 +27,7 @@ module Oga
       def to_xml
         return "<?#{name}#{text}?>"
       end
+      alias_method :to_html, :to_xml
 
       ##
       # @return [String]

--- a/lib/oga/xml/xml_declaration.rb
+++ b/lib/oga/xml/xml_declaration.rb
@@ -47,6 +47,7 @@ module Oga
 
         return "<?xml #{pairs.join(' ')} ?>"
       end
+      alias_method :to_html, :to_xml
 
       ##
       # @return [String]

--- a/spec/oga/xml/attribute_spec.rb
+++ b/spec/oga/xml/attribute_spec.rb
@@ -47,6 +47,16 @@ describe Oga::XML::Attribute do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     example 'convert an attribute to XML' do
       attr = described_class.new(:name => 'foo', :value => 'bar')

--- a/spec/oga/xml/cdata_spec.rb
+++ b/spec/oga/xml/cdata_spec.rb
@@ -14,6 +14,16 @@ describe Oga::XML::Cdata do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     before do
       @instance = described_class.new(:text => 'foo')

--- a/spec/oga/xml/character_node_spec.rb
+++ b/spec/oga/xml/character_node_spec.rb
@@ -14,6 +14,16 @@ describe Oga::XML::CharacterNode do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     example 'convert the node to XML' do
       described_class.new(:text => 'a').to_xml.should == 'a'

--- a/spec/oga/xml/comment_spec.rb
+++ b/spec/oga/xml/comment_spec.rb
@@ -14,6 +14,16 @@ describe Oga::XML::Comment do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     before do
       @instance = described_class.new(:text => 'foo')

--- a/spec/oga/xml/doctype_spec.rb
+++ b/spec/oga/xml/doctype_spec.rb
@@ -14,6 +14,16 @@ describe Oga::XML::Doctype do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     example 'generate a bare minimum representation' do
       described_class.new(:name => 'html').to_xml.should == '<!DOCTYPE html>'

--- a/spec/oga/xml/document_spec.rb
+++ b/spec/oga/xml/document_spec.rb
@@ -30,6 +30,16 @@ describe Oga::XML::Document do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     before do
       child = Oga::XML::Comment.new(:text => 'foo')

--- a/spec/oga/xml/element_spec.rb
+++ b/spec/oga/xml/element_spec.rb
@@ -246,6 +246,16 @@ describe Oga::XML::Element do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     example 'generate the corresponding XML' do
       described_class.new(:name => 'p').to_xml.should == '<p></p>'

--- a/spec/oga/xml/processing_instruction_spec.rb
+++ b/spec/oga/xml/processing_instruction_spec.rb
@@ -11,6 +11,16 @@ describe Oga::XML::ProcessingInstruction do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     example 'conver the node into XML' do
       node = described_class.new(:name => 'foo', :text => ' bar ')

--- a/spec/oga/xml/text_spec.rb
+++ b/spec/oga/xml/text_spec.rb
@@ -14,6 +14,16 @@ describe Oga::XML::Text do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     before do
       @instance = described_class.new(:text => 'foo')

--- a/spec/oga/xml/xml_declaration_spec.rb
+++ b/spec/oga/xml/xml_declaration_spec.rb
@@ -28,6 +28,16 @@ describe Oga::XML::XmlDeclaration do
     end
   end
 
+  context '#to_html' do
+    before do
+      @instance = described_class.new
+    end
+
+    example 'to_xml should be aliased as to_html' do
+      @instance.method(:to_xml).should == @instance.method(:to_html)
+    end
+  end
+
   context '#to_xml' do
     before do
       @instance = described_class.new(


### PR DESCRIPTION
Here is one addition up for discussion: Alias the `#to_xml` methods as `#to_html` 

This at least for me makes the api more usable and consistent. eg. writing

``` ruby
Oga.parse_html("<html><body></body></html>").to_html
```

Instead of 

``` ruby
Oga.parse_html("<html><body></body></html>").to_xml
```

I don't know if this is the best way to implement this, but since both xml and html use the same parser, a simple alias seemed the cleanest solution.

Comments, discussion? 
