### PR TITLE
Patch to Oga Upstream to fix "Oga Parser doesn't handle dots in XML T…

### DIFF
--- a/ext/ragel/base_lexer.rl
+++ b/ext/ragel/base_lexer.rl
@@ -48,7 +48,7 @@
 
     newline    = '\r\n' | '\n' | '\r';
     whitespace = [ \t];
-    ident_char = [a-zA-Z0-9\-_];
+    ident_char = [a-zA-Z0-9\-_\.];
     identifier = ident_char+;
 
     whitespace_or_newline = whitespace | newline;

--- a/spec/oga/xml/lexer/elements_spec.rb
+++ b/spec/oga/xml/lexer/elements_spec.rb
@@ -307,4 +307,12 @@ describe Oga::XML::Lexer do
       ]
     end
   end
+  
+  it 'lexes an element with inline dots' do
+    lex('<SOAP..TestMapping..MappablePerson>').should == [
+      [:T_ELEM_NAME, "SOAP..TestMapping..MappablePerson", 1], 
+      [:T_ELEM_END, nil, 1]
+    ]
+  end
+  
 end


### PR DESCRIPTION
Original problem description is at rubyjedi/soap4r#7

Mahalo for your time in reviewing this fix.
