### PR TITLE
Fixes #118 - decoding invalid entities.

### DIFF
--- a/lib/oga/xml/entities.rb
+++ b/lib/oga/xml/entities.rb
@@ -59,11 +59,18 @@ module Oga
       REGULAR_ENTITY = /&[a-zA-Z0-9]+;/
 
       ##
-      # Regexp for matching XML/HTML entities such as "&#38;".
+      # Regexp for matching XML/HTML numeric entities such as "&#38;".
       #
       # @return [Regexp]
       #
-      CODEPOINT_ENTITY = /&#(x[a-fA-F0-9]+|\d+);/
+      NUMERIC_CODE_POINT_ENTITY = /&#(\d+);/
+
+      ##
+      # Regexp for matching XML/HTML hex entities such as "&#x3C;".
+      #
+      # @return [Regexp]
+      #
+      HEX_CODE_POINT_ENTITY = /&#x([a-fA-F0-9]+);/
 
       ##
       # @return [Regexp]
@@ -89,8 +96,14 @@ module Oga
         input = input.gsub(REGULAR_ENTITY, mapping)
 
         if input.include?(AMPERSAND)
-          input = input.gsub(CODEPOINT_ENTITY) do |match|
-            [$1.start_with?('x') ? Integer($1[1..-1], 16) : Integer($1, 10)].pack('U*')
+          input = input.gsub(NUMERIC_CODE_POINT_ENTITY) do
+            [Integer($1, 10)].pack('U*')
+          end
+        end
+
+        if input.include?(AMPERSAND)
+          input = input.gsub(HEX_CODE_POINT_ENTITY) do
+            [Integer($1, 16)].pack('U*')
           end
         end
 

--- a/lib/oga/xml/entities.rb
+++ b/lib/oga/xml/entities.rb
@@ -63,7 +63,7 @@ module Oga
       #
       # @return [Regexp]
       #
-      CODEPOINT_ENTITY = /&#(x)?([a-zA-Z0-9]+);/
+      CODEPOINT_ENTITY = /&#(x[a-fA-F0-9]+|\d+);/
 
       ##
       # @return [Regexp]
@@ -90,7 +90,7 @@ module Oga
 
         if input.include?(AMPERSAND)
           input = input.gsub(CODEPOINT_ENTITY) do |match|
-            [$1 ? Integer($2, 16) : Integer($2, 10)].pack('U*')
+            [$1.start_with?('x') ? Integer($1[1..-1], 16) : Integer($1, 10)].pack('U*')
           end
         end
 

--- a/spec/oga/xml/entities_spec.rb
+++ b/spec/oga/xml/entities_spec.rb
@@ -73,6 +73,18 @@ describe Oga::XML::Entities do
     it 'decodes numeric entities starting with a 0' do
       described_class.decode('&#038;').should == '&'
     end
+
+    it 'preserves entity-like tokens' do
+      described_class.decode('&#TAB;').should == '&#TAB;'
+    end
+
+    it 'preserves entity-like hex tokens' do
+      described_class.decode('&#x;').should == '&#x;'
+    end
+
+    it 'preserves entity-like letters in non-hex mode' do
+      described_class.decode('&#123A;').should == '&#123A;'
+    end
   end
 
   describe 'encode' do


### PR DESCRIPTION
Previous regular expression was too greedy in terms of matching letters from outside of A-F hex scope, and matching letters when not in hex mode.

I am not entirely happy with line 93 now, it would definitely by clearer if we ran did it in two steps (first for hex then for decimal entities) but I'm not sure if that's doable from the performance standpoint.