### PR TITLE
Fixes #129 - lexing superfluous end tags.

### DIFF
--- a/lib/oga/xml/lexer.rb
+++ b/lib/oga/xml/lexer.rb
@@ -512,8 +512,11 @@ module Oga
           end
         end
 
-        add_token(:T_ELEM_END)
+        # Prevents a superfluous end tag of a self-closing HTML tag from
+        # closing its parent element prematurely
+        return if html? && name && name != current_element
 
+        add_token(:T_ELEM_END)
         @elements.pop
       end
 

--- a/spec/oga/html/lexer/closing_mismatch_spec.rb
+++ b/spec/oga/html/lexer/closing_mismatch_spec.rb
@@ -9,5 +9,16 @@ describe Oga::XML::Lexer do
         [:T_ELEM_END, nil, 1]
       ]
     end
+
+    it 'lexes a <param> element' do
+      lex_html('<object><param></param><param></param></object>').should == [
+        [:T_ELEM_NAME, 'object', 1],
+        [:T_ELEM_NAME, 'param', 1],
+        [:T_ELEM_END, nil, 1],
+        [:T_ELEM_NAME, 'param', 1],
+        [:T_ELEM_END, nil, 1],
+        [:T_ELEM_END, nil, 1]
+      ]
+    end
   end
 end


### PR DESCRIPTION
Prevents a superfluous end tag of a self-closing HTML tag from
closing its parent element prematurely, for example:

```html
<object><param></param><param></param></object>
```

(note <param> is self closing) being turned into:

```html
<object><param/></object><param/>
```