### PR TITLE
Change build order to optimize build speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ install:
   - bundle install --retry=3
 
 rvm:
+  - jruby
   - 1.9
   - 2.0
   - 2.1
   - 2.2
   - rbx
-  - jruby
 
 matrix:
   allow_failures:


### PR DESCRIPTION
I was able to shave ~4 minutes off the Travis CI build time just by changing the order:

<img width="994" alt="94fe19a2-469b-11e6-9d75-ee9a37c71266" src="https://cloud.githubusercontent.com/assets/10308/16779497/66580026-4827-11e6-9b37-34fe224ecedd.png">
