### PR TITLE
Ignore nondeterministic test failure of Rubinius on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,16 @@ rvm:
   - jruby
 
 matrix:
+  allow_failures:
+    - rvm: rbx
+      os: osx
   exclude:
     # Binaries for these rubies aren't available on OS X :<
     - rvm: 2.2
       os: osx
     - rvm: jruby
       os: osx
+  fast_finish: true
 
 notifications:
   email:


### PR DESCRIPTION
Rubinius is failing nondeterministically so I add it to the allowed failures list.