### PR TITLE
Add a number of syntactic sugar features from libxml

### DIFF
--- a/lib/oga/xml/element.rb
+++ b/lib/oga/xml/element.rb
@@ -91,6 +91,8 @@ module Oga
         found ? found.value : nil
       end
 
+      alias_method :[], :get
+
       # Adds a new attribute to the element.
       #
       # @param [Oga::XML::Attribute] attribute
@@ -113,11 +115,7 @@ module Oga
         if found
           found.value = value
         else
-          if name.include?(':')
-            ns, name = name.split(':')
-          else
-            ns = nil
-          end
+          name, ns = split_name(name)
 
           attr = Attribute.new(
             :name           => name,
@@ -128,6 +126,8 @@ module Oga
           add_attribute(attr)
         end
       end
+
+      alias_method :[]=, :set
 
       # Removes an attribute from the element.
       #

--- a/spec/oga/xml/element_spec.rb
+++ b/spec/oga/xml/element_spec.rb
@@ -129,6 +129,13 @@ describe Oga::XML::Element do
     end
   end
 
+  describe '#[]' do
+    it 'is an alias to get' do
+      described_class.instance_method(:[]).should ==
+        described_class.instance_method(:get)
+    end
+  end
+
   describe '#add_attribute' do
     before do
       @element   = described_class.new
@@ -161,6 +168,14 @@ describe Oga::XML::Element do
       @element.get('class').should == 'foo'
     end
 
+    it 'supports the use of Symbols for attribute names' do
+      @element.set(:foo, 'foo')
+      @element.get('foo').should == 'foo'
+
+      @element.set('bar', 'bar')
+      @element.get(:bar).should == 'bar'
+    end
+
     it 'adds a new attribute with a namespace' do
       @element.set('x:bar', 'foo')
 
@@ -183,6 +198,13 @@ describe Oga::XML::Element do
       @element.set('foo', 'baz')
 
       @element.get('foo').should == 'baz'
+    end
+  end
+
+  describe '#[]=' do
+    it 'is an alias to set' do
+      described_class.instance_method(:[]=).should ==
+        described_class.instance_method(:set)
     end
   end
 


### PR DESCRIPTION
When porting some [old code](https://github.com/directededge/directed-edge-bindings/commit/4be7b2bf7150e8b17f991168b9f76811961e77f6) from libxml-ruby to oga, there were a number of things that I found slightly nicer in the libxml API that were easy enough to pull over to Oga.  I realize it's probable that there were left out for a reason, but since the changes were minor, I thought I'd go ahead and throw them together to see if they'd be merged.

- Document#root_element

Gets the top level element in the document, rather than having to grab it from
the children.

- Node#<<

Makes it possible to append children or text in-line.

- Element#[]

Fetches an attribute's value using subscript operator

- Element#[]=

Sets an attribute's value using subscript operator