### PR TITLE
Ruby 2.4 Fixnum deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :mingw_19, :ruby_19 do
-  gem 'json', '~> 1.8'
+  gem 'json', '~> 2.0'
 end
 
 group :benchmarking do

--- a/lib/oga/xpath/conversion.rb
+++ b/lib/oga/xpath/conversion.rb
@@ -76,7 +76,7 @@ module Oga
 
         if value.is_a?(Float)
           bool = !value.nan? && !value.zero?
-        elsif value.is_a?(Fixnum)
+        elsif value.is_a?(Integer)
           bool = !value.zero?
         elsif value.respond_to?(:empty?)
           bool = !value.empty?


### PR DESCRIPTION
In Ruby 2.4, Fixnum is deprecated and the following produces a warning:

$ irb
irb(main):001:0> puts RUBY_VERSION
2.4.0
=> nil
irb(main):002:0> require 'oga'
=> true
irb(main):003:0> Oga.parse_xml('<people><person>Alice</person></people>').css(':nth-child(1)')
/Users/pcheah/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/oga-2.7/lib/oga/xpath/conversion.rb:79: warning: constant ::Fixnum is deprecated
=> NodeSet(Element(name: "people" children: NodeSet(Element(name: "person" children: NodeSet(Text("Alice"))))), Element(name: "person" children: NodeSet(Text("Alice"))))
irb(main):004:0>
$

So oga/xpath/conversion.rb needs to test for Integer instead of Fixnum. 
Also, it appears that json 1.8.3 no longer builds under Ruby 2.4, so the gemfile has to be upgraded to json 2.0.