### PR TITLE
Silence warnings

### DIFF
--- a/lib/oga/xml/attribute.rb
+++ b/lib/oga/xml/attribute.rb
@@ -34,10 +34,11 @@ module Oga
       # @option options [String] :value
       # @option options [Oga::XML::Element] :element
       def initialize(options = {})
-        @name    = options[:name]
-        @value   = options[:value]
-        @element = options[:element]
-
+        @name           = options[:name]
+        @value          = options[:value]
+        @element        = options[:element]
+        @decoded        = false
+        @namespace      = nil
         @namespace_name = options[:namespace_name]
       end
 

--- a/lib/oga/xml/element.rb
+++ b/lib/oga/xml/element.rb
@@ -34,10 +34,11 @@ module Oga
       def initialize(options = {})
         super
 
-        @name           = options[:name]
-        @namespace_name = options[:namespace_name]
-        @attributes     = options[:attributes] || []
-        @namespaces     = options[:namespaces] || {}
+        @name                 = options[:name]
+        @namespace_name       = options[:namespace_name]
+        @attributes           = options[:attributes] || []
+        @namespaces           = options[:namespaces] || {}
+        @available_namespaces = nil
 
         link_attributes
         register_namespaces_from_attributes

--- a/lib/oga/xml/sax_parser.rb
+++ b/lib/oga/xml/sax_parser.rb
@@ -74,18 +74,7 @@ module Oga
         super(*args)
       end
 
-      # Delegate all callbacks to the handler object.
-      instance_methods.grep(/^(on_|after_)/).each do |method|
-        eval <<-EOF, nil, __FILE__, __LINE__ + 1
-        def #{method}(*args)
-          run_callback(:#{method}, *args)
-
-          return
-        end
-        EOF
-      end
-
-      # Manually overwrite `on_element` so we can ensure that `after_element`
+      # Manually define `on_element` so we can ensure that `after_element`
       # always receives the namespace and name.
       #
       # @see [Oga::XML::Parser#on_element]
@@ -96,7 +85,7 @@ module Oga
         [namespace, name]
       end
 
-      # Manually overwrite `after_element` so it can take a namespace and name.
+      # Manually define `after_element` so it can take a namespace and name.
       # This differs a bit from the regular `after_element` which only takes an
       # {Oga::XML::Element} instance.
       #
@@ -107,7 +96,7 @@ module Oga
         return
       end
 
-      # Manually overwrite this method since for this one we _do_ want the
+      # Manually define this method since for this one we _do_ want the
       # return value so it can be passed to `on_element`.
       #
       # @see [Oga::XML::Parser#on_attribute]
@@ -155,6 +144,21 @@ module Oga
         end
 
         return
+      end
+
+      # Delegate remaining callbacks to the handler object.
+      existing_methods = instance_methods(false)
+
+      instance_methods.grep(/^(on_|after_)/).each do |method|
+        next if existing_methods.include?(method)
+
+        eval <<-EOF, nil, __FILE__, __LINE__ + 1
+        def #{method}(*args)
+          run_callback(:#{method}, *args)
+
+          return
+        end
+        EOF
       end
 
       private


### PR DESCRIPTION
This is an attempt at fixing the human-emitted code that generates walls of warnings when using Oga with Rake 11+.

Fixes part of #179.