### PR TITLE
Fix ruby 3.4 future frozen string warning

### DIFF
--- a/lib/oga/xml/node_set.rb
+++ b/lib/oga/xml/node_set.rb
@@ -267,7 +267,7 @@ module Oga
       #
       # @return [String]
       def text
-        text = ''
+        text = +''
 
         @nodes.each do |node|
           if node.respond_to?(:text) and !node.is_a?(Comment)


### PR DESCRIPTION
When updating to ruby 3.4.x in my rails project, I get warnings such as this one

```
~/.ruby/gems/oga-3.4/lib/oga/xml/node_set.rb:274: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This PR fixes the warning.